### PR TITLE
fix: DIVE PR workflow cache handoff

### DIFF
--- a/.github/workflows/dive-pr-e2e.yaml
+++ b/.github/workflows/dive-pr-e2e.yaml
@@ -20,7 +20,10 @@ jobs:
         id: yarn-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-
+            node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install DIVE-Demo dependencies (if cache not found)
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -52,6 +55,11 @@ jobs:
         continue-on-error: true
         working-directory: .
 
+      - name: Verify DIVE package
+        run: |
+          test -f node_modules/@shopware-ag/dive/build/engine/Dive.d.ts
+          grep -q 'disposeAsync(): Promise<void>;' node_modules/@shopware-ag/dive/build/engine/Dive.d.ts
+
   build:
     runs-on: ubuntu-latest
     needs: install-dive
@@ -67,7 +75,8 @@ jobs:
         id: yarn-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: Build
         run: yarn build
 
@@ -87,7 +96,8 @@ jobs:
         id: yarn-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: Search for cached playwright browsers
         uses: actions/cache@main
         id: playwright-cache
@@ -120,7 +130,8 @@ jobs:
         id: yarn-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: Load playwright browsers from cache
         uses: actions/cache@main
         id: playwright-cache

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -36,7 +36,7 @@ jobs:
         id: yarn-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}
       - name: Install DIVE-Demo dependencies (if cache not found)
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -54,7 +54,8 @@ jobs:
         id: yarn-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: Build
         run: yarn build
   playwright-install:
@@ -71,7 +72,8 @@ jobs:
         id: yarn-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: Search for cached playwright browsers
         uses: actions/cache@main
         id: playwright-cache
@@ -103,7 +105,8 @@ jobs:
         id: yarn-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: Load playwright browsers from cache
         uses: actions/cache@main
         id: playwright-cache


### PR DESCRIPTION
## Summary
- use a run-scoped `node_modules` cache key for `Test with DIVE PR` after installing the requested DIVE ref
- require downstream build/playwright/e2e jobs to restore that exact cache instead of falling back to stale lockfile-only node_modules
- apply the same exact within-run handoff to the normal `Pull Request` workflow, without cross-run restore keys, so stale DIVE type artifacts are not reused
- verify the installed DIVE package exposes the expected `disposeAsync` type before downstream jobs run

## Validation
- `git diff --check`
- Ruby YAML parse for `.github/workflows/dive-pr-e2e.yaml` and `.github/workflows/pull-request.yaml`
- PR #35 latest GitHub Actions run: yarn install, build, playwright install, and e2e shards 1-4 passed

Note: local Prettier check could not run because the current `node_modules` cannot resolve `prettier-plugin-multiline-arrays`.