### PR TITLE
feat: material demo overhaul

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -48,6 +48,39 @@
   --ui-active-bg: #0066cc;
   --ui-active-border: #0088ff;
   --ui-active-text: #fff;
+
+  /* tweakpane glass theme */
+  --tp-base-background-color: var(--ui-panel-bg);
+  --tp-base-border-radius: 0.75rem;
+  --tp-base-font-family: inherit;
+  --tp-base-font-size: 0.8rem;
+  --tp-base-shadow-color: rgba(0, 0, 0, 0.16);
+  --tp-blade-border-radius: 0.35rem;
+  --tp-blade-horizontal-padding: 0.45rem;
+  --tp-blade-value-width: 150px;
+  --tp-button-background-color: var(--ui-btn-bg);
+  --tp-button-background-color-active: var(--ui-active-bg);
+  --tp-button-background-color-focus: var(--ui-btn-bg-hover);
+  --tp-button-background-color-hover: var(--ui-btn-bg-hover);
+  --tp-button-foreground-color: var(--ui-btn-text);
+  --tp-container-background-color: rgba(255, 255, 255, 0.28);
+  --tp-container-background-color-active: rgba(255, 255, 255, 0.7);
+  --tp-container-background-color-focus: rgba(255, 255, 255, 0.6);
+  --tp-container-background-color-hover: rgba(255, 255, 255, 0.46);
+  --tp-container-foreground-color: var(--ui-btn-text);
+  --tp-container-horizontal-padding: 0.45rem;
+  --tp-container-vertical-padding: 0.45rem;
+  --tp-container-unit-spacing: 0.35rem;
+  --tp-container-unit-size: 1.75rem;
+  --tp-input-background-color: rgba(255, 255, 255, 0.48);
+  --tp-input-background-color-active: rgba(255, 255, 255, 0.82);
+  --tp-input-background-color-focus: rgba(255, 255, 255, 0.72);
+  --tp-input-background-color-hover: rgba(255, 255, 255, 0.62);
+  --tp-input-foreground-color: var(--ui-btn-text);
+  --tp-label-foreground-color: var(--ui-label-text);
+  --tp-monitor-background-color: rgba(255, 255, 255, 0.42);
+  --tp-monitor-foreground-color: var(--ui-btn-text);
+  --tp-groove-foreground-color: var(--ui-panel-border);
 }
 
 html.dark {
@@ -74,6 +107,17 @@ html.dark {
   --ui-active-bg: #0066cc;
   --ui-active-border: #0088ff;
   --ui-active-text: #fff;
+
+  --tp-base-shadow-color: rgba(0, 0, 0, 0.3);
+  --tp-container-background-color: rgba(255, 255, 255, 0.08);
+  --tp-container-background-color-active: rgba(255, 255, 255, 0.18);
+  --tp-container-background-color-focus: rgba(255, 255, 255, 0.16);
+  --tp-container-background-color-hover: rgba(255, 255, 255, 0.12);
+  --tp-input-background-color: rgba(0, 0, 0, 0.22);
+  --tp-input-background-color-active: rgba(255, 255, 255, 0.16);
+  --tp-input-background-color-focus: rgba(255, 255, 255, 0.13);
+  --tp-input-background-color-hover: rgba(255, 255, 255, 0.1);
+  --tp-monitor-background-color: rgba(0, 0, 0, 0.28);
 }
 
 *,
@@ -294,6 +338,77 @@ button.active:hover:not(:disabled) {
   -webkit-backdrop-filter: blur(8px);
   color: var(--ui-btn-text);
   font-size: 0.8rem;
+}
+
+/* ── Global tweakpane glass theme ── */
+
+body .tp-rotv,
+body .tp-popv {
+  border: 1px solid var(--ui-panel-border);
+  border-radius: var(--tp-base-border-radius);
+  background-color: var(--tp-base-background-color);
+  background-clip: padding-box;
+  box-shadow: 0 0.75rem 2rem var(--tp-base-shadow-color);
+  font-family: var(--tp-base-font-family);
+  font-size: var(--tp-base-font-size);
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.25;
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+}
+
+body .tp-rotv {
+  overflow: hidden;
+}
+
+body .tp-rotv_b,
+body .tp-fldv_b {
+  font-weight: 600;
+}
+
+body .tp-lblv {
+  min-height: var(--tp-container-unit-size);
+}
+
+body .tp-lblv_l {
+  padding-left: 0.2rem;
+}
+
+body .tp-txtv_i,
+body .tp-coltxtv_ms,
+body .tp-colswv,
+body .tp-ckbv_w,
+body .tp-p2dv_b,
+body .tp-btnv_b,
+body .tp-lstv_s {
+  box-shadow: inset 0 0 0 1px var(--ui-btn-border);
+}
+
+body .tp-txtv_i:hover,
+body .tp-coltxtv_ms:hover,
+body .tp-colswv:hover,
+body .tp-ckbv_i:hover + .tp-ckbv_w,
+body .tp-p2dv_b:hover,
+body .tp-btnv_b:hover,
+body .tp-lstv_s:hover {
+  box-shadow: inset 0 0 0 1px var(--ui-btn-border-hover);
+}
+
+body .tp-sldv_t::before,
+body .tp-sldv_k::before {
+  height: 3px;
+}
+
+body .tp-sldv_k::after {
+  box-shadow:
+    inset 0 0 0 1px var(--ui-btn-border),
+    0 0.15rem 0.45rem rgba(0, 0, 0, 0.18);
+}
+
+body .tp-fldv_i::before {
+  width: 2px;
+  opacity: 0.7;
 }
 
 /* ── Checkbox button (label that looks like a button) ── */

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -48,6 +48,8 @@
   --ui-active-bg: #0066cc;
   --ui-active-border: #0088ff;
   --ui-active-text: #fff;
+  --ui-scrollbar-thumb: rgba(44, 62, 80, 0.34);
+  --ui-scrollbar-thumb-hover: rgba(44, 62, 80, 0.5);
 
   /* tweakpane glass theme */
   --tp-base-background-color: var(--ui-panel-bg);
@@ -107,6 +109,8 @@ html.dark {
   --ui-active-bg: #0066cc;
   --ui-active-border: #0088ff;
   --ui-active-text: #fff;
+  --ui-scrollbar-thumb: rgba(255, 255, 255, 0.34);
+  --ui-scrollbar-thumb-hover: rgba(255, 255, 255, 0.5);
 
   --tp-base-shadow-color: rgba(0, 0, 0, 0.3);
   --tp-container-background-color: rgba(255, 255, 255, 0.08);
@@ -409,6 +413,56 @@ body .tp-sldv_k::after {
 body .tp-fldv_i::before {
   width: 2px;
   opacity: 0.7;
+}
+
+.dive-material-panes {
+  padding: 8px 0 8px 8px;
+  border: 1px solid var(--ui-panel-border);
+  border-radius: var(--tp-base-border-radius);
+  background-color: var(--tp-base-background-color);
+  background-clip: padding-box;
+  box-shadow: 0 0.75rem 2rem var(--tp-base-shadow-color);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.dive-material-panes > .tp-rotv {
+  border: 0;
+  background-color: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+.dive-material-panes.is-scrolling {
+  scrollbar-color: var(--ui-scrollbar-thumb) transparent;
+}
+
+.dive-material-panes::-webkit-scrollbar {
+  width: 8px;
+}
+
+.dive-material-panes::-webkit-scrollbar-track {
+  background: transparent;
+  margin-block: 8px;
+}
+
+.dive-material-panes::-webkit-scrollbar-thumb {
+  min-height: 32px;
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-color: transparent;
+  background-clip: padding-box;
+}
+
+.dive-material-panes.is-scrolling::-webkit-scrollbar-thumb {
+  background-color: var(--ui-scrollbar-thumb);
+}
+
+.dive-material-panes.is-scrolling::-webkit-scrollbar-thumb:hover {
+  background-color: var(--ui-scrollbar-thumb-hover);
 }
 
 /* ── Checkbox button (label that looks like a button) ── */

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -416,14 +416,30 @@ body .tp-fldv_i::before {
 }
 
 .dive-material-panes {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(320px, calc(100vw - 16px));
+  max-height: calc(100vh - 16px);
+  min-height: 0;
   padding: 8px 0 8px 8px;
   border: 1px solid var(--ui-panel-border);
   border-radius: var(--tp-base-border-radius);
   background-color: var(--tp-base-background-color);
   background-clip: padding-box;
   box-shadow: 0 0.75rem 2rem var(--tp-base-shadow-color);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  pointer-events: auto;
+  scrollbar-gutter: auto;
   backdrop-filter: blur(14px) saturate(140%);
   -webkit-backdrop-filter: blur(14px) saturate(140%);
+  -webkit-overflow-scrolling: touch;
   scrollbar-width: thin;
   scrollbar-color: transparent transparent;
 }

--- a/src/composables/useDiveMaterialControls.ts
+++ b/src/composables/useDiveMaterialControls.ts
@@ -38,6 +38,7 @@ export function useDiveMaterialControls({
 }: DiveMaterialControlsOptions) {
     let paneContainer: HTMLDivElement | null = null;
     let materialPanes: MaterialPane[] = [];
+    let paneScrollbarHideTimeout: number | null = null;
 
     function rebuildPane() {
         disposePane();
@@ -57,6 +58,7 @@ export function useDiveMaterialControls({
                 container: paneContainer,
             });
             pane.element.style.width = '100%';
+            pane.element.style.flex = '0 0 auto';
 
             const materialPane = {
                 pane,
@@ -75,6 +77,10 @@ export function useDiveMaterialControls({
     function disposePane() {
         materialPanes.forEach((materialPane) => materialPane.pane.dispose());
         materialPanes = [];
+        if (paneScrollbarHideTimeout !== null) {
+            window.clearTimeout(paneScrollbarHideTimeout);
+            paneScrollbarHideTimeout = null;
+        }
         paneContainer?.remove();
         paneContainer = null;
     }
@@ -103,7 +109,23 @@ export function useDiveMaterialControls({
                     label: 'Use',
                     disabled: !hasTexture,
                 })
-                .on('change', () => applyAndRefresh(materialPane));
+                .on('change', (event) => {
+                    if (!event.value) {
+                        if (control.only) {
+                            setOnlyMaterialMap(materialPane.state, null);
+                        }
+
+                        if (control.useAsDiffuse) {
+                            setUseAsDiffuseMode(
+                                materialPane.state,
+                                layer.key,
+                                false,
+                            );
+                        }
+                    }
+
+                    applyAndRefresh(materialPane);
+                });
             const only = folder
                 .addBinding(control, 'only', {
                     label: 'Only',
@@ -202,7 +224,7 @@ export function useDiveMaterialControls({
             .on('change', () => applyAndRefresh(materialPane));
         materialPane.pane
             .addBinding(materialPane.state, 'emissiveColor', {
-                label: 'Emissive',
+                label: 'Emissive Color',
             })
             .on('change', () => applyAndRefresh(materialPane));
         materialPane.pane
@@ -247,19 +269,53 @@ export function useDiveMaterialControls({
     function createPaneContainer() {
         const container = document.createElement('div');
         container.className = 'dive-material-panes';
-        container.style.position = 'absolute';
+        container.style.position = 'fixed';
         container.style.top = '8px';
         container.style.right = '8px';
-        container.style.zIndex = '10';
-        container.style.width = '300px';
-        container.style.maxHeight = 'calc(100% - 16px)';
+        container.style.bottom = '8px';
+        container.style.zIndex = '20';
+        container.style.width = 'min(320px, calc(100vw - 16px))';
+        container.style.minHeight = '0';
         container.style.overflowY = 'auto';
+        container.style.overflowX = 'hidden';
+        container.style.overscrollBehavior = 'contain';
+        container.style.scrollbarGutter = 'auto';
         container.style.display = 'flex';
         container.style.flexDirection = 'column';
         container.style.gap = '8px';
+        container.style.pointerEvents = 'auto';
+        container.style.setProperty('-webkit-overflow-scrolling', 'touch');
+        container.addEventListener('scroll', revealPaneScrollbar, {
+            passive: true,
+        });
+        container.addEventListener('wheel', stopPaneScrollPropagation, {
+            passive: true,
+        });
+        container.addEventListener('touchmove', stopPaneScrollPropagation, {
+            passive: true,
+        });
         document.body.appendChild(container);
 
         return container;
+    }
+
+    function stopPaneScrollPropagation(event: Event) {
+        event.stopPropagation();
+    }
+
+    function revealPaneScrollbar() {
+        if (!paneContainer) return;
+
+        paneContainer.classList.add('is-scrolling');
+
+        if (paneScrollbarHideTimeout !== null) {
+            window.clearTimeout(paneScrollbarHideTimeout);
+        }
+
+        paneScrollbarHideTimeout = window.setTimeout(() => {
+            paneContainer?.classList.remove('is-scrolling');
+            paneScrollbarHideTimeout = null;
+        }, 800);
     }
 
     function getPaneTitle(

--- a/src/composables/useDiveMaterialControls.ts
+++ b/src/composables/useDiveMaterialControls.ts
@@ -1,4 +1,4 @@
-import type { BindingApi } from '@tweakpane/core';
+import type { BindingApi, FolderApi } from '@tweakpane/core';
 import { Pane } from 'tweakpane';
 import {
     applyDiveMaterialState,
@@ -93,17 +93,17 @@ export function useDiveMaterialControls({
     }
 
     function bindMaterialPane(materialPane: MaterialPane) {
-        bindBaseMaterialProperties(materialPane);
-
         DIVE_MATERIAL_MAPS.forEach((layer) => {
             const hasTexture = Boolean(
                 materialPane.state.sourceTextures[layer.key],
             );
             const folder = materialPane.pane.addFolder({
                 title: layer.title,
-                expanded: hasTexture,
             });
             const control = materialPane.state.controls[layer.key];
+
+            bindLayerMaterialProperties(folder, materialPane, layer.key);
+
             const use = folder
                 .addBinding(control, 'use', {
                     label: 'Use',
@@ -160,89 +160,106 @@ export function useDiveMaterialControls({
         });
     }
 
-    function bindBaseMaterialProperties(materialPane: MaterialPane) {
-        materialPane.pane
-            .addBinding(materialPane.state, 'baseColor', {
-                label: 'Base Color',
-            })
-            .on('change', () => applyAndRefresh(materialPane));
+    function bindLayerMaterialProperties(
+        folder: FolderApi,
+        materialPane: MaterialPane,
+        key: DiveMaterialMapKey,
+    ) {
+        switch (key) {
+            case 'map':
+                folder
+                    .addBinding(materialPane.state, 'baseColor', {
+                        label: 'Base Color',
+                    })
+                    .on('change', () => applyAndRefresh(materialPane));
+                break;
 
-        materialPane.pane
-            .addBinding(materialPane.state, 'roughness', {
-                label: 'Roughness',
-                min: 0,
-                max: 1,
-                step: 0.01,
-            })
-            .on('change', () => applyAndRefresh(materialPane));
-        materialPane.pane
-            .addBinding(materialPane.state, 'metalness', {
-                label: 'Metalness',
-                min: 0,
-                max: 1,
-                step: 0.01,
-            })
-            .on('change', () => applyAndRefresh(materialPane));
-        materialPane.pane
-            .addBinding(materialPane.state, 'alpha', {
-                label: 'Alpha',
-                min: 0,
-                max: 1,
-                step: 0.01,
-            })
-            .on('change', () => applyAndRefresh(materialPane));
-        materialPane.pane
-            .addBinding(materialPane.state, 'alphaTest', {
-                label: 'Alpha Test',
-                min: 0,
-                max: 1,
-                step: 0.01,
-            })
-            .on('change', () => applyAndRefresh(materialPane));
-        materialPane.pane
-            .addBinding(materialPane.state, 'normalScale', {
-                label: 'Normal Scale',
-                x: {
-                    min: -2,
-                    max: 2,
-                    step: 0.01,
-                },
-                y: {
-                    min: -2,
-                    max: 2,
-                    step: 0.01,
-                },
-            })
-            .on('change', () => applyAndRefresh(materialPane));
-        materialPane.pane
-            .addBinding(materialPane.state, 'aoIntensity', {
-                label: 'AO Intensity',
-                min: 0,
-                max: 1,
-                step: 0.01,
-            })
-            .on('change', () => applyAndRefresh(materialPane));
-        materialPane.pane
-            .addBinding(materialPane.state, 'emissiveColor', {
-                label: 'Emissive Color',
-            })
-            .on('change', () => applyAndRefresh(materialPane));
-        materialPane.pane
-            .addBinding(materialPane.state, 'emissiveIntensity', {
-                label: 'Emissive Intensity',
-                min: 0,
-                max: 5,
-                step: 0.01,
-            })
-            .on('change', () => applyAndRefresh(materialPane));
-        materialPane.pane
-            .addBinding(materialPane.state, 'envMapIntensity', {
-                label: 'Env Intensity',
-                min: 0,
-                max: 5,
-                step: 0.01,
-            })
-            .on('change', () => applyAndRefresh(materialPane));
+            case 'normalMap':
+                folder
+                    .addBinding(materialPane.state, 'normalScale', {
+                        label: 'Intensity',
+                        x: {
+                            min: -2,
+                            max: 2,
+                            step: 0.01,
+                        },
+                        y: {
+                            min: -2,
+                            max: 2,
+                            step: 0.01,
+                        },
+                    })
+                    .on('change', () => applyAndRefresh(materialPane));
+                break;
+
+            case 'roughnessMap':
+                folder
+                    .addBinding(materialPane.state, 'roughness', {
+                        label: 'Base Roughness',
+                        min: 0,
+                        max: 1,
+                        step: 0.01,
+                    })
+                    .on('change', () => applyAndRefresh(materialPane));
+                break;
+
+            case 'metalnessMap':
+                folder
+                    .addBinding(materialPane.state, 'metalness', {
+                        label: 'Base Metalness',
+                        min: 0,
+                        max: 1,
+                        step: 0.01,
+                    })
+                    .on('change', () => applyAndRefresh(materialPane));
+                break;
+
+            case 'alphaMap':
+                folder
+                    .addBinding(materialPane.state, 'alpha', {
+                        label: 'Base Alpha',
+                        min: 0,
+                        max: 1,
+                        step: 0.01,
+                    })
+                    .on('change', () => applyAndRefresh(materialPane));
+                folder
+                    .addBinding(materialPane.state, 'alphaTest', {
+                        label: 'Alpha Test',
+                        min: 0,
+                        max: 1,
+                        step: 0.01,
+                    })
+                    .on('change', () => applyAndRefresh(materialPane));
+                break;
+
+            case 'aoMap':
+                folder
+                    .addBinding(materialPane.state, 'aoIntensity', {
+                        label: 'Intensity',
+                        min: 0,
+                        max: 1,
+                        step: 0.01,
+                    })
+                    .on('change', () => applyAndRefresh(materialPane));
+                break;
+
+            case 'emissiveMap':
+                folder
+                    .addBinding(materialPane.state, 'emissiveColor', {
+                        label: 'Color',
+                    })
+                    .on('change', () => applyAndRefresh(materialPane));
+                folder
+                    .addBinding(materialPane.state, 'emissiveIntensity', {
+                        label: 'Intensity',
+                        min: 0,
+                        max: 5,
+                        step: 0.01,
+                    })
+                    .on('change', () => applyAndRefresh(materialPane));
+                break;
+        }
     }
 
     function applyAndRefresh(materialPane: MaterialPane) {

--- a/src/composables/useDiveMaterialControls.ts
+++ b/src/composables/useDiveMaterialControls.ts
@@ -87,11 +87,7 @@ export function useDiveMaterialControls({
     }
 
     function bindMaterialPane(materialPane: MaterialPane) {
-        materialPane.pane
-            .addBinding(materialPane.state, 'baseColor', {
-                label: 'Base Color',
-            })
-            .on('change', () => applyAndRefresh(materialPane));
+        bindBaseMaterialProperties(materialPane);
 
         DIVE_MATERIAL_MAPS.forEach((layer) => {
             const hasTexture = Boolean(
@@ -140,6 +136,91 @@ export function useDiveMaterialControls({
                 useAsDiffuse,
             });
         });
+    }
+
+    function bindBaseMaterialProperties(materialPane: MaterialPane) {
+        materialPane.pane
+            .addBinding(materialPane.state, 'baseColor', {
+                label: 'Base Color',
+            })
+            .on('change', () => applyAndRefresh(materialPane));
+
+        materialPane.pane
+            .addBinding(materialPane.state, 'roughness', {
+                label: 'Roughness',
+                min: 0,
+                max: 1,
+                step: 0.01,
+            })
+            .on('change', () => applyAndRefresh(materialPane));
+        materialPane.pane
+            .addBinding(materialPane.state, 'metalness', {
+                label: 'Metalness',
+                min: 0,
+                max: 1,
+                step: 0.01,
+            })
+            .on('change', () => applyAndRefresh(materialPane));
+        materialPane.pane
+            .addBinding(materialPane.state, 'alpha', {
+                label: 'Alpha',
+                min: 0,
+                max: 1,
+                step: 0.01,
+            })
+            .on('change', () => applyAndRefresh(materialPane));
+        materialPane.pane
+            .addBinding(materialPane.state, 'alphaTest', {
+                label: 'Alpha Test',
+                min: 0,
+                max: 1,
+                step: 0.01,
+            })
+            .on('change', () => applyAndRefresh(materialPane));
+        materialPane.pane
+            .addBinding(materialPane.state, 'normalScale', {
+                label: 'Normal Scale',
+                x: {
+                    min: -2,
+                    max: 2,
+                    step: 0.01,
+                },
+                y: {
+                    min: -2,
+                    max: 2,
+                    step: 0.01,
+                },
+            })
+            .on('change', () => applyAndRefresh(materialPane));
+        materialPane.pane
+            .addBinding(materialPane.state, 'aoIntensity', {
+                label: 'AO Intensity',
+                min: 0,
+                max: 1,
+                step: 0.01,
+            })
+            .on('change', () => applyAndRefresh(materialPane));
+        materialPane.pane
+            .addBinding(materialPane.state, 'emissiveColor', {
+                label: 'Emissive',
+            })
+            .on('change', () => applyAndRefresh(materialPane));
+        materialPane.pane
+            .addBinding(materialPane.state, 'emissiveIntensity', {
+                label: 'Emissive Intensity',
+                min: 0,
+                max: 5,
+                step: 0.01,
+            })
+            .on('change', () => applyAndRefresh(materialPane));
+        materialPane.pane
+            .addBinding(materialPane.state, 'envMapIntensity', {
+                label: 'Env Intensity',
+                min: 0,
+                max: 5,
+                step: 0.01,
+            })
+            .on('change', () => applyAndRefresh(materialPane));
     }
 
     function applyAndRefresh(materialPane: MaterialPane) {

--- a/src/composables/useDiveMaterialControls.ts
+++ b/src/composables/useDiveMaterialControls.ts
@@ -4,6 +4,8 @@ import {
     applyDiveMaterialState,
     createDiveMaterialState,
     DIVE_MATERIAL_MAPS,
+    markEmissiveColorChangedManually,
+    markEmissiveIntensityChangedManually,
     resolveDiveMaterials,
     resetDiveMaterialState,
     setMaterialMapUse,
@@ -24,6 +26,7 @@ type MaterialPane = {
     material: DiveInspectableMaterial;
     state: DiveMaterialState;
     bindings: Map<DiveMaterialMapKey, BindingSet>;
+    isRefreshing: boolean;
 };
 
 type DiveMaterialControlsOptions = {
@@ -64,12 +67,13 @@ export function useDiveMaterialControls({
                 material,
                 state,
                 bindings: new Map<DiveMaterialMapKey, BindingSet>(),
+                isRefreshing: false,
             };
 
             materialPanes.push(materialPane);
             bindMaterialPane(materialPane);
             syncBindings(materialPane);
-            pane.refresh();
+            refreshPane(materialPane);
         });
     }
 
@@ -226,7 +230,14 @@ export function useDiveMaterialControls({
                     .addBinding(materialPane.state, 'emissiveColor', {
                         label: 'Color',
                     })
-                    .on('change', () => applyAndRefresh(materialPane));
+                    .on('change', () => {
+                        if (materialPane.isRefreshing) return;
+
+                        markEmissiveColorChangedManually(
+                            materialPane.state,
+                        );
+                        applyAndRefresh(materialPane);
+                    });
                 folder
                     .addBinding(materialPane.state, 'emissiveIntensity', {
                         label: 'Intensity',
@@ -234,7 +245,14 @@ export function useDiveMaterialControls({
                         max: 5,
                         step: 0.01,
                     })
-                    .on('change', () => applyAndRefresh(materialPane));
+                    .on('change', () => {
+                        if (materialPane.isRefreshing) return;
+
+                        markEmissiveIntensityChangedManually(
+                            materialPane.state,
+                        );
+                        applyAndRefresh(materialPane);
+                    });
                 break;
         }
     }
@@ -242,7 +260,17 @@ export function useDiveMaterialControls({
     function applyAndRefresh(materialPane: MaterialPane) {
         applyDiveMaterialState(materialPane.material, materialPane.state);
         syncBindings(materialPane);
-        materialPane.pane.refresh();
+        refreshPane(materialPane);
+    }
+
+    function refreshPane(materialPane: MaterialPane) {
+        materialPane.isRefreshing = true;
+
+        try {
+            materialPane.pane.refresh();
+        } finally {
+            materialPane.isRefreshing = false;
+        }
     }
 
     function syncBindings(materialPane: MaterialPane) {

--- a/src/composables/useDiveMaterialControls.ts
+++ b/src/composables/useDiveMaterialControls.ts
@@ -293,9 +293,9 @@ export function useDiveMaterialControls({
         container.style.position = 'fixed';
         container.style.top = '8px';
         container.style.right = '8px';
-        container.style.bottom = '8px';
         container.style.zIndex = '20';
         container.style.width = 'min(320px, calc(100vw - 16px))';
+        container.style.maxHeight = 'calc(100vh - 16px)';
         container.style.minHeight = '0';
         container.style.overflowY = 'auto';
         container.style.overflowX = 'hidden';

--- a/src/composables/useDiveMaterialControls.ts
+++ b/src/composables/useDiveMaterialControls.ts
@@ -290,22 +290,6 @@ export function useDiveMaterialControls({
     function createPaneContainer() {
         const container = document.createElement('div');
         container.className = 'dive-material-panes';
-        container.style.position = 'fixed';
-        container.style.top = '8px';
-        container.style.right = '8px';
-        container.style.zIndex = '20';
-        container.style.width = 'min(320px, calc(100vw - 16px))';
-        container.style.maxHeight = 'calc(100vh - 16px)';
-        container.style.minHeight = '0';
-        container.style.overflowY = 'auto';
-        container.style.overflowX = 'hidden';
-        container.style.overscrollBehavior = 'contain';
-        container.style.scrollbarGutter = 'auto';
-        container.style.display = 'flex';
-        container.style.flexDirection = 'column';
-        container.style.gap = '8px';
-        container.style.pointerEvents = 'auto';
-        container.style.setProperty('-webkit-overflow-scrolling', 'touch');
         container.addEventListener('scroll', revealPaneScrollbar, {
             passive: true,
         });

--- a/src/composables/useDiveMaterialControls.ts
+++ b/src/composables/useDiveMaterialControls.ts
@@ -6,7 +6,7 @@ import {
     DIVE_MATERIAL_MAPS,
     resolveDiveMaterials,
     resetDiveMaterialState,
-    setOnlyMaterialMap,
+    setMaterialMapUse,
     setUseAsDiffuseMode,
     type DiveInspectableMaterial,
     type DiveMaterialMapKey,
@@ -16,7 +16,6 @@ import {
 
 type BindingSet = {
     use: BindingApi<unknown, boolean>;
-    only: BindingApi<unknown, boolean>;
     useAsDiffuse: BindingApi<unknown, boolean>;
 };
 
@@ -110,31 +109,10 @@ export function useDiveMaterialControls({
                     disabled: !hasTexture,
                 })
                 .on('change', (event) => {
-                    if (!event.value) {
-                        if (control.only) {
-                            setOnlyMaterialMap(materialPane.state, null);
-                        }
-
-                        if (control.useAsDiffuse) {
-                            setUseAsDiffuseMode(
-                                materialPane.state,
-                                layer.key,
-                                false,
-                            );
-                        }
-                    }
-
-                    applyAndRefresh(materialPane);
-                });
-            const only = folder
-                .addBinding(control, 'only', {
-                    label: 'Exclusively',
-                    disabled: !hasTexture,
-                })
-                .on('change', (event) => {
-                    setOnlyMaterialMap(
+                    setMaterialMapUse(
                         materialPane.state,
-                        event.value ? layer.key : null,
+                        layer.key,
+                        event.value,
                     );
                     applyAndRefresh(materialPane);
                 });
@@ -154,7 +132,6 @@ export function useDiveMaterialControls({
 
             materialPane.bindings.set(layer.key, {
                 use,
-                only,
                 useAsDiffuse,
             });
         });
@@ -278,7 +255,6 @@ export function useDiveMaterialControls({
             );
 
             layerBindings.use.disabled = !hasTexture;
-            layerBindings.only.disabled = !hasTexture;
             layerBindings.useAsDiffuse.disabled = !hasTexture;
         });
     }

--- a/src/composables/useDiveMaterialControls.ts
+++ b/src/composables/useDiveMaterialControls.ts
@@ -87,6 +87,12 @@ export function useDiveMaterialControls({
     }
 
     function bindMaterialPane(materialPane: MaterialPane) {
+        materialPane.pane
+            .addBinding(materialPane.state, 'baseColor', {
+                label: 'Base Color',
+            })
+            .on('change', () => applyAndRefresh(materialPane));
+
         DIVE_MATERIAL_MAPS.forEach((layer) => {
             const hasTexture = Boolean(
                 materialPane.state.sourceTextures[layer.key],

--- a/src/composables/useDiveMaterialControls.ts
+++ b/src/composables/useDiveMaterialControls.ts
@@ -106,7 +106,7 @@ export function useDiveMaterialControls({
 
             const use = folder
                 .addBinding(control, 'use', {
-                    label: 'Use',
+                    label: 'Use Map',
                     disabled: !hasTexture,
                 })
                 .on('change', (event) => {
@@ -128,7 +128,7 @@ export function useDiveMaterialControls({
                 });
             const only = folder
                 .addBinding(control, 'only', {
-                    label: 'Only',
+                    label: 'Exclusively',
                     disabled: !hasTexture,
                 })
                 .on('change', (event) => {
@@ -169,7 +169,7 @@ export function useDiveMaterialControls({
             case 'map':
                 folder
                     .addBinding(materialPane.state, 'baseColor', {
-                        label: 'Base Color',
+                        label: 'Color',
                     })
                     .on('change', () => applyAndRefresh(materialPane));
                 break;
@@ -195,7 +195,7 @@ export function useDiveMaterialControls({
             case 'roughnessMap':
                 folder
                     .addBinding(materialPane.state, 'roughness', {
-                        label: 'Base Roughness',
+                        label: 'Roughness',
                         min: 0,
                         max: 1,
                         step: 0.01,
@@ -206,7 +206,7 @@ export function useDiveMaterialControls({
             case 'metalnessMap':
                 folder
                     .addBinding(materialPane.state, 'metalness', {
-                        label: 'Base Metalness',
+                        label: 'Metalness',
                         min: 0,
                         max: 1,
                         step: 0.01,
@@ -217,7 +217,7 @@ export function useDiveMaterialControls({
             case 'alphaMap':
                 folder
                     .addBinding(materialPane.state, 'alpha', {
-                        label: 'Base Alpha',
+                        label: 'Alpha',
                         min: 0,
                         max: 1,
                         step: 0.01,

--- a/src/utils/diveMaterialControls.test.ts
+++ b/src/utils/diveMaterialControls.test.ts
@@ -3,6 +3,7 @@ import { BoxGeometry, Mesh, MeshStandardMaterial, Object3D, Texture } from 'thre
 import {
     applyDiveMaterialState,
     createDiveMaterialState,
+    markEmissiveIntensityChangedManually,
     resolveDiveMaterial,
     resolveDiveMaterials,
     resetDiveMaterialState,
@@ -10,6 +11,7 @@ import {
     setUseAsDiffuseMode,
     type DiveMaterialModel,
     type DiveInspectableMaterial,
+    markEmissiveColorChangedManually,
 } from './diveMaterialControls';
 
 function createMaterial() {
@@ -140,7 +142,7 @@ describe('diveMaterialControls', () => {
         expect(material.emissiveMap).toBeNull();
     });
 
-    it('keeps emissive values synced when the emissive map is disabled', () => {
+    it('resets and restores emissive values when the emissive map is toggled', () => {
         const material = createMaterial();
         const state = createDiveMaterialState(material);
 
@@ -151,17 +153,57 @@ describe('diveMaterialControls', () => {
         applyDiveMaterialState(material, state);
 
         expect(state.controls.emissiveMap.use).toBe(false);
-        expect(state.emissiveColor).toBe('#ffffff');
-        expect(state.emissiveIntensity).toBe(4);
+        expect(state.emissiveColor).toBe('#000000');
+        expect(state.emissiveIntensity).toBe(0);
         expect(material.emissiveMap).toBeNull();
-        expect(material.emissive.getHexString()).toBe('ffffff');
-        expect(material.emissiveIntensity).toBe(4);
+        expect(material.emissive.getHexString()).toBe('000000');
+        expect(material.emissiveIntensity).toBe(0);
 
-        state.emissiveColor = '#112233';
-        state.emissiveIntensity = 1.25;
+        state.controls.emissiveMap.use = true;
+        setMaterialMapUse(state, 'emissiveMap', true);
         applyDiveMaterialState(material, state);
 
+        expect(state.controls.emissiveMap.use).toBe(true);
+        expect(state.emissiveColor).toBe('#ffffff');
+        expect(state.emissiveIntensity).toBe(4);
+        expect(material.emissiveMap).toBe(state.sourceTextures.emissiveMap);
+        expect(material.emissive.getHexString()).toBe('ffffff');
+        expect(material.emissiveIntensity).toBe(4);
+    });
+
+    it('keeps manual emissive values after the emissive map is disabled', () => {
+        const material = createMaterial();
+        const state = createDiveMaterialState(material);
+
+        state.emissiveColor = '#ffffff';
+        state.emissiveIntensity = 4;
+        state.controls.emissiveMap.use = false;
+        setMaterialMapUse(state, 'emissiveMap', false);
+        applyDiveMaterialState(material, state);
+
+        state.emissiveColor = '#112233';
+        markEmissiveColorChangedManually(state);
+        applyDiveMaterialState(material, state);
+
+        expect(material.emissive.getHexString()).toBe('112233');
+        expect(material.emissiveIntensity).toBe(0);
+
+        state.emissiveIntensity = 1.25;
+        markEmissiveIntensityChangedManually(state);
+        applyDiveMaterialState(material, state);
+
+        expect(state.controls.emissiveMap.use).toBe(false);
         expect(material.emissiveMap).toBeNull();
+        expect(material.emissive.getHexString()).toBe('112233');
+        expect(material.emissiveIntensity).toBe(1.25);
+
+        state.controls.emissiveMap.use = true;
+        setMaterialMapUse(state, 'emissiveMap', true);
+        applyDiveMaterialState(material, state);
+
+        expect(state.emissiveColor).toBe('#112233');
+        expect(state.emissiveIntensity).toBe(1.25);
+        expect(material.emissiveMap).toBe(state.sourceTextures.emissiveMap);
         expect(material.emissive.getHexString()).toBe('112233');
         expect(material.emissiveIntensity).toBe(1.25);
     });

--- a/src/utils/diveMaterialControls.test.ts
+++ b/src/utils/diveMaterialControls.test.ts
@@ -6,7 +6,7 @@ import {
     resolveDiveMaterial,
     resolveDiveMaterials,
     resetDiveMaterialState,
-    setOnlyMaterialMap,
+    setMaterialMapUse,
     setUseAsDiffuseMode,
     type DiveMaterialModel,
     type DiveInspectableMaterial,
@@ -69,24 +69,7 @@ describe('diveMaterialControls', () => {
         expect(resolveDiveMaterials(model)).toEqual([]);
     });
 
-    it('disables every other map when one map is used exclusively', () => {
-        const material = createMaterial();
-        const state = createDiveMaterialState(material);
-        const originalNormalMap = material.normalMap;
-
-        setOnlyMaterialMap(state, 'normalMap');
-        applyDiveMaterialState(material, state);
-
-        expect(material.map).toBeNull();
-        expect(material.normalMap).toBe(originalNormalMap);
-        expect(material.roughnessMap).toBeNull();
-        expect(material.metalnessMap).toBeNull();
-        expect(material.alphaMap).toBeNull();
-        expect(material.aoMap).toBeNull();
-        expect(material.emissiveMap).toBeNull();
-    });
-
-    it('uses any selected map as diffuse preview without only mode', () => {
+    it('uses any selected map only as diffuse preview', () => {
         const material = createMaterial();
         const state = createDiveMaterialState(material);
         const originalNormalMap = material.normalMap;
@@ -95,23 +78,7 @@ describe('diveMaterialControls', () => {
         applyDiveMaterialState(material, state);
 
         expect(material.map).toBe(originalNormalMap);
-        expect(material.normalMap).toBe(originalNormalMap);
-    });
-
-    it('keeps the diffuse replacement when exclusive mode is cleared', () => {
-        const material = createMaterial();
-        const state = createDiveMaterialState(material);
-        const originalNormalMap = material.normalMap;
-
-        setOnlyMaterialMap(state, 'normalMap');
-        setUseAsDiffuseMode(state, 'normalMap', true);
-        applyDiveMaterialState(material, state);
-
-        setOnlyMaterialMap(state, null);
-        applyDiveMaterialState(material, state);
-
-        expect(material.map).toBe(originalNormalMap);
-        expect(material.normalMap).toBe(state.sourceTextures.normalMap);
+        expect(material.normalMap).toBeNull();
     });
 
     it('only allows one diffuse replacement at a time', () => {
@@ -133,26 +100,31 @@ describe('diveMaterialControls', () => {
         const state = createDiveMaterialState(material);
         const originalEmissiveMap = material.emissiveMap;
 
+        state.emissiveColor = '#ffffff';
+        state.emissiveIntensity = 2;
         setUseAsDiffuseMode(state, 'emissiveMap', true);
         applyDiveMaterialState(material, state);
 
         expect(material.map).toBe(originalEmissiveMap);
-        expect(material.emissiveMap).toBe(originalEmissiveMap);
+        expect(material.emissiveMap).toBeNull();
+        expect(material.emissive.getHexString()).toBe('000000');
+        expect(material.emissiveIntensity).toBe(0);
     });
 
-    it('does not remove every map when the exclusive map is disabled', () => {
+    it('disables emissive contribution while any map is used as a diffuse preview', () => {
         const material = createMaterial();
         const state = createDiveMaterialState(material);
-        const originalMap = material.map;
         const originalNormalMap = material.normalMap;
 
-        setOnlyMaterialMap(state, 'emissiveMap');
-        state.controls.emissiveMap.use = false;
+        state.emissiveColor = '#ffffff';
+        state.emissiveIntensity = 4;
+        setUseAsDiffuseMode(state, 'normalMap', true);
         applyDiveMaterialState(material, state);
 
-        expect(material.map).toBe(originalMap);
-        expect(material.normalMap).toBe(originalNormalMap);
+        expect(material.map).toBe(originalNormalMap);
         expect(material.emissiveMap).toBeNull();
+        expect(material.emissive.getHexString()).toBe('000000');
+        expect(material.emissiveIntensity).toBe(0);
     });
 
     it('does not use a disabled map as a diffuse preview', () => {
@@ -166,6 +138,32 @@ describe('diveMaterialControls', () => {
 
         expect(material.map).toBe(originalMap);
         expect(material.emissiveMap).toBeNull();
+    });
+
+    it('keeps emissive values synced when the emissive map is disabled', () => {
+        const material = createMaterial();
+        const state = createDiveMaterialState(material);
+
+        state.emissiveColor = '#ffffff';
+        state.emissiveIntensity = 4;
+        state.controls.emissiveMap.use = false;
+        setMaterialMapUse(state, 'emissiveMap', false);
+        applyDiveMaterialState(material, state);
+
+        expect(state.controls.emissiveMap.use).toBe(false);
+        expect(state.emissiveColor).toBe('#ffffff');
+        expect(state.emissiveIntensity).toBe(4);
+        expect(material.emissiveMap).toBeNull();
+        expect(material.emissive.getHexString()).toBe('ffffff');
+        expect(material.emissiveIntensity).toBe(4);
+
+        state.emissiveColor = '#112233';
+        state.emissiveIntensity = 1.25;
+        applyDiveMaterialState(material, state);
+
+        expect(material.emissiveMap).toBeNull();
+        expect(material.emissive.getHexString()).toBe('112233');
+        expect(material.emissiveIntensity).toBe(1.25);
     });
 
     it('applies the configured base color to the material', () => {
@@ -235,7 +233,6 @@ describe('diveMaterialControls', () => {
         state.emissiveColor = '#778899';
         state.emissiveIntensity = 3;
         state.controls.roughnessMap.use = false;
-        setOnlyMaterialMap(state, 'normalMap');
         setUseAsDiffuseMode(state, 'normalMap', true);
         applyDiveMaterialState(material, state);
 
@@ -256,7 +253,6 @@ describe('diveMaterialControls', () => {
         expect(material.emissiveIntensity).toBe(1.5);
         expect(material.roughnessMap).toBe(state.sourceTextures.roughnessMap);
         expect(material.emissiveMap).toBe(originalEmissiveMap);
-        expect(state.controls.normalMap.only).toBe(false);
         expect(state.controls.normalMap.useAsDiffuse).toBe(false);
     });
 });

--- a/src/utils/diveMaterialControls.test.ts
+++ b/src/utils/diveMaterialControls.test.ts
@@ -126,11 +126,23 @@ describe('diveMaterialControls', () => {
         expect(state.controls.roughnessMap.useAsDiffuse).toBe(true);
     });
 
+    it('applies the configured base color to the material', () => {
+        const material = createMaterial();
+        const state = createDiveMaterialState(material);
+
+        state.baseColor = '#336699';
+        applyDiveMaterialState(material, state);
+
+        expect(material.color.getHexString()).toBe('336699');
+    });
+
     it('resets preview state back to all original maps', () => {
         const material = createMaterial();
+        material.color.setStyle('#884422');
         const state = createDiveMaterialState(material);
         const originalMap = material.map;
 
+        state.baseColor = '#336699';
         state.controls.roughnessMap.use = false;
         setOnlyMaterialMap(state, 'normalMap');
         setUseAsDiffuseMode(state, 'normalMap', true);
@@ -140,6 +152,8 @@ describe('diveMaterialControls', () => {
         applyDiveMaterialState(material, state);
 
         expect(material.map).toBe(originalMap);
+        expect(material.color.getHexString()).toBe('884422');
+        expect(state.baseColor).toBe('#884422');
         expect(material.roughnessMap).toBe(state.sourceTextures.roughnessMap);
         expect(state.controls.normalMap.only).toBe(false);
         expect(state.controls.normalMap.useAsDiffuse).toBe(false);

--- a/src/utils/diveMaterialControls.test.ts
+++ b/src/utils/diveMaterialControls.test.ts
@@ -136,13 +136,65 @@ describe('diveMaterialControls', () => {
         expect(material.color.getHexString()).toBe('336699');
     });
 
+    it('applies configured base material values to the material', () => {
+        const material = createMaterial();
+        const state = createDiveMaterialState(material);
+
+        state.roughness = 0.25;
+        state.metalness = 0.75;
+        state.alpha = 0.4;
+        state.alphaTest = 0.1;
+        state.normalScale = {
+            x: 0.5,
+            y: -0.75,
+        };
+        state.aoIntensity = 0.35;
+        state.emissiveColor = '#445566';
+        state.emissiveIntensity = 2.5;
+        state.envMapIntensity = 1.5;
+        applyDiveMaterialState(material, state);
+
+        expect(material.roughness).toBe(0.25);
+        expect(material.metalness).toBe(0.75);
+        expect(material.opacity).toBe(0.4);
+        expect(material.transparent).toBe(true);
+        expect(material.alphaTest).toBe(0.1);
+        expect(material.normalScale.x).toBe(0.5);
+        expect(material.normalScale.y).toBe(-0.75);
+        expect(material.aoMapIntensity).toBe(0.35);
+        expect(material.emissive.getHexString()).toBe('445566');
+        expect(material.emissiveIntensity).toBe(2.5);
+        expect(material.envMapIntensity).toBe(1.5);
+    });
+
     it('resets preview state back to all original maps', () => {
         const material = createMaterial();
         material.color.setStyle('#884422');
+        material.roughness = 0.35;
+        material.metalness = 0.65;
+        material.opacity = 0.8;
+        material.alphaTest = 0.2;
+        material.normalScale.set(0.75, -0.5);
+        material.aoMapIntensity = 0.45;
+        material.emissive.setStyle('#223344');
+        material.emissiveIntensity = 1.5;
+        material.envMapIntensity = 0.7;
         const state = createDiveMaterialState(material);
         const originalMap = material.map;
 
         state.baseColor = '#336699';
+        state.roughness = 0.9;
+        state.metalness = 0.1;
+        state.alpha = 0.3;
+        state.alphaTest = 0.05;
+        state.normalScale = {
+            x: 1.25,
+            y: 1.5,
+        };
+        state.aoIntensity = 0.9;
+        state.emissiveColor = '#778899';
+        state.emissiveIntensity = 3;
+        state.envMapIntensity = 2;
         state.controls.roughnessMap.use = false;
         setOnlyMaterialMap(state, 'normalMap');
         setUseAsDiffuseMode(state, 'normalMap', true);
@@ -154,6 +206,16 @@ describe('diveMaterialControls', () => {
         expect(material.map).toBe(originalMap);
         expect(material.color.getHexString()).toBe('884422');
         expect(state.baseColor).toBe('#884422');
+        expect(material.roughness).toBe(0.35);
+        expect(material.metalness).toBe(0.65);
+        expect(material.opacity).toBe(0.8);
+        expect(material.alphaTest).toBe(0.2);
+        expect(material.normalScale.x).toBe(0.75);
+        expect(material.normalScale.y).toBe(-0.5);
+        expect(material.aoMapIntensity).toBe(0.45);
+        expect(material.emissive.getHexString()).toBe('223344');
+        expect(material.emissiveIntensity).toBe(1.5);
+        expect(material.envMapIntensity).toBe(0.7);
         expect(material.roughnessMap).toBe(state.sourceTextures.roughnessMap);
         expect(state.controls.normalMap.only).toBe(false);
         expect(state.controls.normalMap.useAsDiffuse).toBe(false);

--- a/src/utils/diveMaterialControls.test.ts
+++ b/src/utils/diveMaterialControls.test.ts
@@ -21,6 +21,7 @@ function createMaterial() {
     material.metalnessMap = new Texture();
     material.alphaMap = new Texture();
     material.aoMap = new Texture();
+    material.emissiveMap = new Texture();
 
     return material;
 }
@@ -82,6 +83,7 @@ describe('diveMaterialControls', () => {
         expect(material.metalnessMap).toBeNull();
         expect(material.alphaMap).toBeNull();
         expect(material.aoMap).toBeNull();
+        expect(material.emissiveMap).toBeNull();
     });
 
     it('uses any selected map as diffuse preview without only mode', () => {
@@ -124,6 +126,46 @@ describe('diveMaterialControls', () => {
         expect(material.map).toBe(originalRoughnessMap);
         expect(state.controls.normalMap.useAsDiffuse).toBe(false);
         expect(state.controls.roughnessMap.useAsDiffuse).toBe(true);
+    });
+
+    it('uses the emissive map as a diffuse preview', () => {
+        const material = createMaterial();
+        const state = createDiveMaterialState(material);
+        const originalEmissiveMap = material.emissiveMap;
+
+        setUseAsDiffuseMode(state, 'emissiveMap', true);
+        applyDiveMaterialState(material, state);
+
+        expect(material.map).toBe(originalEmissiveMap);
+        expect(material.emissiveMap).toBe(originalEmissiveMap);
+    });
+
+    it('does not remove every map when the exclusive map is disabled', () => {
+        const material = createMaterial();
+        const state = createDiveMaterialState(material);
+        const originalMap = material.map;
+        const originalNormalMap = material.normalMap;
+
+        setOnlyMaterialMap(state, 'emissiveMap');
+        state.controls.emissiveMap.use = false;
+        applyDiveMaterialState(material, state);
+
+        expect(material.map).toBe(originalMap);
+        expect(material.normalMap).toBe(originalNormalMap);
+        expect(material.emissiveMap).toBeNull();
+    });
+
+    it('does not use a disabled map as a diffuse preview', () => {
+        const material = createMaterial();
+        const state = createDiveMaterialState(material);
+        const originalMap = material.map;
+
+        setUseAsDiffuseMode(state, 'emissiveMap', true);
+        state.controls.emissiveMap.use = false;
+        applyDiveMaterialState(material, state);
+
+        expect(material.map).toBe(originalMap);
+        expect(material.emissiveMap).toBeNull();
     });
 
     it('applies the configured base color to the material', () => {
@@ -181,6 +223,7 @@ describe('diveMaterialControls', () => {
         material.envMapIntensity = 0.7;
         const state = createDiveMaterialState(material);
         const originalMap = material.map;
+        const originalEmissiveMap = material.emissiveMap;
 
         state.baseColor = '#336699';
         state.roughness = 0.9;
@@ -217,6 +260,7 @@ describe('diveMaterialControls', () => {
         expect(material.emissiveIntensity).toBe(1.5);
         expect(material.envMapIntensity).toBe(0.7);
         expect(material.roughnessMap).toBe(state.sourceTextures.roughnessMap);
+        expect(material.emissiveMap).toBe(originalEmissiveMap);
         expect(state.controls.normalMap.only).toBe(false);
         expect(state.controls.normalMap.useAsDiffuse).toBe(false);
     });

--- a/src/utils/diveMaterialControls.test.ts
+++ b/src/utils/diveMaterialControls.test.ts
@@ -193,7 +193,6 @@ describe('diveMaterialControls', () => {
         state.aoIntensity = 0.35;
         state.emissiveColor = '#445566';
         state.emissiveIntensity = 2.5;
-        state.envMapIntensity = 1.5;
         applyDiveMaterialState(material, state);
 
         expect(material.roughness).toBe(0.25);
@@ -206,7 +205,6 @@ describe('diveMaterialControls', () => {
         expect(material.aoMapIntensity).toBe(0.35);
         expect(material.emissive.getHexString()).toBe('445566');
         expect(material.emissiveIntensity).toBe(2.5);
-        expect(material.envMapIntensity).toBe(1.5);
     });
 
     it('resets preview state back to all original maps', () => {
@@ -220,7 +218,6 @@ describe('diveMaterialControls', () => {
         material.aoMapIntensity = 0.45;
         material.emissive.setStyle('#223344');
         material.emissiveIntensity = 1.5;
-        material.envMapIntensity = 0.7;
         const state = createDiveMaterialState(material);
         const originalMap = material.map;
         const originalEmissiveMap = material.emissiveMap;
@@ -237,7 +234,6 @@ describe('diveMaterialControls', () => {
         state.aoIntensity = 0.9;
         state.emissiveColor = '#778899';
         state.emissiveIntensity = 3;
-        state.envMapIntensity = 2;
         state.controls.roughnessMap.use = false;
         setOnlyMaterialMap(state, 'normalMap');
         setUseAsDiffuseMode(state, 'normalMap', true);
@@ -258,7 +254,6 @@ describe('diveMaterialControls', () => {
         expect(material.aoMapIntensity).toBe(0.45);
         expect(material.emissive.getHexString()).toBe('223344');
         expect(material.emissiveIntensity).toBe(1.5);
-        expect(material.envMapIntensity).toBe(0.7);
         expect(material.roughnessMap).toBe(state.sourceTextures.roughnessMap);
         expect(material.emissiveMap).toBe(originalEmissiveMap);
         expect(state.controls.normalMap.only).toBe(false);

--- a/src/utils/diveMaterialControls.ts
+++ b/src/utils/diveMaterialControls.ts
@@ -5,6 +5,9 @@ export type DiveMaterialNormalScale = {
     y: number;
 };
 
+const DISABLED_EMISSIVE_COLOR = '#000000';
+const DISABLED_EMISSIVE_INTENSITY = 0;
+
 export const DIVE_MATERIAL_MAPS = [
     {
         key: 'map',
@@ -48,7 +51,6 @@ export type DiveMaterialModel = Object3D & {
 
 export type DiveMaterialMapControl = {
     use: boolean;
-    only: boolean;
     useAsDiffuse: boolean;
 };
 
@@ -135,23 +137,10 @@ export function createDiveMaterialState(
         sourceTransparent: material.transparent,
         controls: createMapRecord(() => ({
             use: true,
-            only: false,
             useAsDiffuse: false,
         })),
         sourceTextures: createMapRecord((key) => material[key] ?? null),
     };
-}
-
-export function getOnlyMaterialMap(state: DiveMaterialState) {
-    return DIVE_MATERIAL_MAPS.find((layer) => {
-        const control = state.controls[layer.key];
-
-        return (
-            control.only &&
-            control.use &&
-            Boolean(state.sourceTextures[layer.key])
-        );
-    })?.key ?? null;
 }
 
 export function getDiffuseMaterialMap(state: DiveMaterialState) {
@@ -166,16 +155,6 @@ export function getDiffuseMaterialMap(state: DiveMaterialState) {
     })?.key ?? null;
 }
 
-export function setOnlyMaterialMap(
-    state: DiveMaterialState,
-    selectedKey: DiveMaterialMapKey | null,
-) {
-    DIVE_MATERIAL_MAPS.forEach((layer) => {
-        const control = state.controls[layer.key];
-        control.only = layer.key === selectedKey;
-    });
-}
-
 export function setUseAsDiffuseMode(
     state: DiveMaterialState,
     key: DiveMaterialMapKey,
@@ -185,6 +164,20 @@ export function setUseAsDiffuseMode(
         state.controls[layer.key].useAsDiffuse =
             enabled && layer.key === key;
     });
+}
+
+export function setMaterialMapUse(
+    state: DiveMaterialState,
+    key: DiveMaterialMapKey,
+    enabled: boolean,
+) {
+    const control = state.controls[key];
+
+    control.use = enabled;
+
+    if (!enabled) {
+        control.useAsDiffuse = false;
+    }
 }
 
 export function resetDiveMaterialState(state: DiveMaterialState) {
@@ -201,7 +194,6 @@ export function resetDiveMaterialState(state: DiveMaterialState) {
     DIVE_MATERIAL_MAPS.forEach((layer) => {
         const control = state.controls[layer.key];
         control.use = true;
-        control.only = false;
         control.useAsDiffuse = false;
     });
 }
@@ -210,7 +202,6 @@ export function applyDiveMaterialState(
     material: DiveInspectableMaterial,
     state: DiveMaterialState,
 ) {
-    const onlyKey = getOnlyMaterialMap(state);
     const diffuseOverrideKey = getDiffuseMaterialMap(state);
 
     material.color.setStyle(state.baseColor);
@@ -220,14 +211,23 @@ export function applyDiveMaterialState(
     material.alphaTest = state.alphaTest;
     material.normalScale.set(state.normalScale.x, state.normalScale.y);
     material.aoMapIntensity = state.aoIntensity;
-    material.emissive.setStyle(state.emissiveColor);
-    material.emissiveIntensity = state.emissiveIntensity;
+
+    if (diffuseOverrideKey) {
+        material.emissive.setStyle(DISABLED_EMISSIVE_COLOR);
+        material.emissiveIntensity = DISABLED_EMISSIVE_INTENSITY;
+    } else {
+        material.emissive.setStyle(state.emissiveColor);
+        material.emissiveIntensity = state.emissiveIntensity;
+    }
 
     DIVE_MATERIAL_MAPS.forEach((layer) => {
         const control = state.controls[layer.key];
-        const layerIsActive = !onlyKey || onlyKey === layer.key;
+        const layerIsDiffusePreview = diffuseOverrideKey === layer.key;
+        const layerIsMutedForDiffusePreview =
+            Boolean(diffuseOverrideKey) &&
+            (layerIsDiffusePreview || layer.key === 'emissiveMap');
         material[layer.key] =
-            control.use && layerIsActive
+            control.use && !layerIsMutedForDiffusePreview
                 ? state.sourceTextures[layer.key]
                 : null;
     });

--- a/src/utils/diveMaterialControls.ts
+++ b/src/utils/diveMaterialControls.ts
@@ -30,6 +30,10 @@ export const DIVE_MATERIAL_MAPS = [
         key: 'aoMap',
         title: 'Ambient Occlusion',
     },
+    {
+        key: 'emissiveMap',
+        title: 'Emissive',
+    },
 ] as const;
 
 export type DiveMaterialMapKey = (typeof DIVE_MATERIAL_MAPS)[number]['key'];
@@ -143,14 +147,27 @@ export function createDiveMaterialState(
 }
 
 export function getOnlyMaterialMap(state: DiveMaterialState) {
-    return DIVE_MATERIAL_MAPS.find((layer) => state.controls[layer.key].only)
-        ?.key ?? null;
+    return DIVE_MATERIAL_MAPS.find((layer) => {
+        const control = state.controls[layer.key];
+
+        return (
+            control.only &&
+            control.use &&
+            Boolean(state.sourceTextures[layer.key])
+        );
+    })?.key ?? null;
 }
 
 export function getDiffuseMaterialMap(state: DiveMaterialState) {
-    return DIVE_MATERIAL_MAPS.find(
-        (layer) => state.controls[layer.key].useAsDiffuse,
-    )?.key ?? null;
+    return DIVE_MATERIAL_MAPS.find((layer) => {
+        const control = state.controls[layer.key];
+
+        return (
+            control.useAsDiffuse &&
+            control.use &&
+            Boolean(state.sourceTextures[layer.key])
+        );
+    })?.key ?? null;
 }
 
 export function setOnlyMaterialMap(

--- a/src/utils/diveMaterialControls.ts
+++ b/src/utils/diveMaterialControls.ts
@@ -80,6 +80,10 @@ export type DiveMaterialState = {
     sourceEmissiveColor: string;
     emissiveIntensity: number;
     sourceEmissiveIntensity: number;
+    storedEmissiveColor: string;
+    restoreEmissiveColorOnMapEnable: boolean;
+    storedEmissiveIntensity: number;
+    restoreEmissiveIntensityOnMapEnable: boolean;
     sourceTransparent: boolean;
     controls: DiveMaterialMapControls;
     sourceTextures: DiveMaterialTextureStore;
@@ -134,6 +138,10 @@ export function createDiveMaterialState(
         sourceEmissiveColor: emissiveColor,
         emissiveIntensity: material.emissiveIntensity,
         sourceEmissiveIntensity: material.emissiveIntensity,
+        storedEmissiveColor: emissiveColor,
+        restoreEmissiveColorOnMapEnable: false,
+        storedEmissiveIntensity: material.emissiveIntensity,
+        restoreEmissiveIntensityOnMapEnable: false,
         sourceTransparent: material.transparent,
         controls: createMapRecord(() => ({
             use: true,
@@ -178,6 +186,46 @@ export function setMaterialMapUse(
     if (!enabled) {
         control.useAsDiffuse = false;
     }
+
+    if (key !== 'emissiveMap') return;
+
+    if (enabled) {
+        if (state.restoreEmissiveColorOnMapEnable || state.restoreEmissiveIntensityOnMapEnable) {
+            state.emissiveColor = state.storedEmissiveColor;
+            state.restoreEmissiveColorOnMapEnable = false;
+            state.emissiveIntensity = state.storedEmissiveIntensity;
+            state.restoreEmissiveIntensityOnMapEnable = false;
+        }
+        return;
+    }
+
+    if (!state.restoreEmissiveColorOnMapEnable && !state.restoreEmissiveIntensityOnMapEnable) {
+        state.storedEmissiveColor = state.emissiveColor;
+        state.restoreEmissiveColorOnMapEnable = true;
+        state.storedEmissiveIntensity = state.emissiveIntensity;
+        state.restoreEmissiveIntensityOnMapEnable = true;
+    }
+
+    state.emissiveColor = DISABLED_EMISSIVE_COLOR;
+    state.emissiveIntensity = DISABLED_EMISSIVE_INTENSITY;
+}
+
+export function markEmissiveColorChangedManually(
+    state: DiveMaterialState,
+) {
+    if (state.controls.emissiveMap.use) return;
+
+    state.storedEmissiveColor = state.emissiveColor;
+    state.restoreEmissiveColorOnMapEnable = false;
+}
+
+export function markEmissiveIntensityChangedManually(
+    state: DiveMaterialState,
+) {
+    if (state.controls.emissiveMap.use) return;
+
+    state.storedEmissiveIntensity = state.emissiveIntensity;
+    state.restoreEmissiveIntensityOnMapEnable = false;
 }
 
 export function resetDiveMaterialState(state: DiveMaterialState) {
@@ -190,6 +238,10 @@ export function resetDiveMaterialState(state: DiveMaterialState) {
     state.aoIntensity = state.sourceAoIntensity;
     state.emissiveColor = state.sourceEmissiveColor;
     state.emissiveIntensity = state.sourceEmissiveIntensity;
+    state.storedEmissiveColor = state.sourceEmissiveColor;
+    state.restoreEmissiveColorOnMapEnable = false;
+    state.storedEmissiveIntensity = state.sourceEmissiveIntensity;
+    state.restoreEmissiveIntensityOnMapEnable = false;
 
     DIVE_MATERIAL_MAPS.forEach((layer) => {
         const control = state.controls[layer.key];
@@ -212,7 +264,7 @@ export function applyDiveMaterialState(
     material.normalScale.set(state.normalScale.x, state.normalScale.y);
     material.aoMapIntensity = state.aoIntensity;
 
-    if (diffuseOverrideKey) {
+    if (diffuseOverrideKey || state.restoreEmissiveColorOnMapEnable) {
         material.emissive.setStyle(DISABLED_EMISSIVE_COLOR);
         material.emissiveIntensity = DISABLED_EMISSIVE_INTENSITY;
     } else {

--- a/src/utils/diveMaterialControls.ts
+++ b/src/utils/diveMaterialControls.ts
@@ -51,6 +51,8 @@ export type DiveMaterialMapControls = Record<
 export type DiveMaterialTextureStore = Record<DiveMaterialMapKey, Texture | null>;
 
 export type DiveMaterialState = {
+    baseColor: string;
+    sourceBaseColor: string;
     controls: DiveMaterialMapControls;
     sourceTextures: DiveMaterialTextureStore;
 };
@@ -81,7 +83,11 @@ export function resolveDiveMaterials(
 export function createDiveMaterialState(
     material: DiveInspectableMaterial,
 ): DiveMaterialState {
+    const baseColor = getMaterialBaseColor(material);
+
     return {
+        baseColor,
+        sourceBaseColor: baseColor,
         controls: createMapRecord(() => ({
             use: true,
             only: false,
@@ -124,6 +130,8 @@ export function setUseAsDiffuseMode(
 }
 
 export function resetDiveMaterialState(state: DiveMaterialState) {
+    state.baseColor = state.sourceBaseColor;
+
     DIVE_MATERIAL_MAPS.forEach((layer) => {
         const control = state.controls[layer.key];
         control.use = true;
@@ -139,6 +147,8 @@ export function applyDiveMaterialState(
     const onlyKey = getOnlyMaterialMap(state);
     const diffuseOverrideKey = getDiffuseMaterialMap(state);
 
+    material.color.setStyle(state.baseColor);
+
     DIVE_MATERIAL_MAPS.forEach((layer) => {
         const control = state.controls[layer.key];
         const layerIsActive = !onlyKey || onlyKey === layer.key;
@@ -153,6 +163,10 @@ export function applyDiveMaterialState(
     }
 
     material.needsUpdate = true;
+}
+
+function getMaterialBaseColor(material: DiveInspectableMaterial) {
+    return `#${material.color.getHexString()}`;
 }
 
 function createMapRecord<Value>(

--- a/src/utils/diveMaterialControls.ts
+++ b/src/utils/diveMaterialControls.ts
@@ -78,8 +78,6 @@ export type DiveMaterialState = {
     sourceEmissiveColor: string;
     emissiveIntensity: number;
     sourceEmissiveIntensity: number;
-    envMapIntensity: number;
-    sourceEnvMapIntensity: number;
     sourceTransparent: boolean;
     controls: DiveMaterialMapControls;
     sourceTextures: DiveMaterialTextureStore;
@@ -134,8 +132,6 @@ export function createDiveMaterialState(
         sourceEmissiveColor: emissiveColor,
         emissiveIntensity: material.emissiveIntensity,
         sourceEmissiveIntensity: material.emissiveIntensity,
-        envMapIntensity: material.envMapIntensity,
-        sourceEnvMapIntensity: material.envMapIntensity,
         sourceTransparent: material.transparent,
         controls: createMapRecord(() => ({
             use: true,
@@ -201,7 +197,6 @@ export function resetDiveMaterialState(state: DiveMaterialState) {
     state.aoIntensity = state.sourceAoIntensity;
     state.emissiveColor = state.sourceEmissiveColor;
     state.emissiveIntensity = state.sourceEmissiveIntensity;
-    state.envMapIntensity = state.sourceEnvMapIntensity;
 
     DIVE_MATERIAL_MAPS.forEach((layer) => {
         const control = state.controls[layer.key];
@@ -227,7 +222,6 @@ export function applyDiveMaterialState(
     material.aoMapIntensity = state.aoIntensity;
     material.emissive.setStyle(state.emissiveColor);
     material.emissiveIntensity = state.emissiveIntensity;
-    material.envMapIntensity = state.envMapIntensity;
 
     DIVE_MATERIAL_MAPS.forEach((layer) => {
         const control = state.controls[layer.key];

--- a/src/utils/diveMaterialControls.ts
+++ b/src/utils/diveMaterialControls.ts
@@ -1,5 +1,10 @@
 import type { Material, MeshStandardMaterial, Object3D, Texture } from 'three';
 
+export type DiveMaterialNormalScale = {
+    x: number;
+    y: number;
+};
+
 export const DIVE_MATERIAL_MAPS = [
     {
         key: 'map',
@@ -53,6 +58,25 @@ export type DiveMaterialTextureStore = Record<DiveMaterialMapKey, Texture | null
 export type DiveMaterialState = {
     baseColor: string;
     sourceBaseColor: string;
+    roughness: number;
+    sourceRoughness: number;
+    metalness: number;
+    sourceMetalness: number;
+    alpha: number;
+    sourceAlpha: number;
+    alphaTest: number;
+    sourceAlphaTest: number;
+    normalScale: DiveMaterialNormalScale;
+    sourceNormalScale: DiveMaterialNormalScale;
+    aoIntensity: number;
+    sourceAoIntensity: number;
+    emissiveColor: string;
+    sourceEmissiveColor: string;
+    emissiveIntensity: number;
+    sourceEmissiveIntensity: number;
+    envMapIntensity: number;
+    sourceEnvMapIntensity: number;
+    sourceTransparent: boolean;
     controls: DiveMaterialMapControls;
     sourceTextures: DiveMaterialTextureStore;
 };
@@ -84,10 +108,31 @@ export function createDiveMaterialState(
     material: DiveInspectableMaterial,
 ): DiveMaterialState {
     const baseColor = getMaterialBaseColor(material);
+    const emissiveColor = getMaterialEmissiveColor(material);
+    const normalScale = getMaterialNormalScale(material);
 
     return {
         baseColor,
         sourceBaseColor: baseColor,
+        roughness: material.roughness,
+        sourceRoughness: material.roughness,
+        metalness: material.metalness,
+        sourceMetalness: material.metalness,
+        alpha: material.opacity,
+        sourceAlpha: material.opacity,
+        alphaTest: material.alphaTest,
+        sourceAlphaTest: material.alphaTest,
+        normalScale: { ...normalScale },
+        sourceNormalScale: normalScale,
+        aoIntensity: material.aoMapIntensity,
+        sourceAoIntensity: material.aoMapIntensity,
+        emissiveColor,
+        sourceEmissiveColor: emissiveColor,
+        emissiveIntensity: material.emissiveIntensity,
+        sourceEmissiveIntensity: material.emissiveIntensity,
+        envMapIntensity: material.envMapIntensity,
+        sourceEnvMapIntensity: material.envMapIntensity,
+        sourceTransparent: material.transparent,
         controls: createMapRecord(() => ({
             use: true,
             only: false,
@@ -131,6 +176,15 @@ export function setUseAsDiffuseMode(
 
 export function resetDiveMaterialState(state: DiveMaterialState) {
     state.baseColor = state.sourceBaseColor;
+    state.roughness = state.sourceRoughness;
+    state.metalness = state.sourceMetalness;
+    state.alpha = state.sourceAlpha;
+    state.alphaTest = state.sourceAlphaTest;
+    state.normalScale = { ...state.sourceNormalScale };
+    state.aoIntensity = state.sourceAoIntensity;
+    state.emissiveColor = state.sourceEmissiveColor;
+    state.emissiveIntensity = state.sourceEmissiveIntensity;
+    state.envMapIntensity = state.sourceEnvMapIntensity;
 
     DIVE_MATERIAL_MAPS.forEach((layer) => {
         const control = state.controls[layer.key];
@@ -148,6 +202,15 @@ export function applyDiveMaterialState(
     const diffuseOverrideKey = getDiffuseMaterialMap(state);
 
     material.color.setStyle(state.baseColor);
+    material.roughness = state.roughness;
+    material.metalness = state.metalness;
+    material.opacity = state.alpha;
+    material.alphaTest = state.alphaTest;
+    material.normalScale.set(state.normalScale.x, state.normalScale.y);
+    material.aoMapIntensity = state.aoIntensity;
+    material.emissive.setStyle(state.emissiveColor);
+    material.emissiveIntensity = state.emissiveIntensity;
+    material.envMapIntensity = state.envMapIntensity;
 
     DIVE_MATERIAL_MAPS.forEach((layer) => {
         const control = state.controls[layer.key];
@@ -162,11 +225,28 @@ export function applyDiveMaterialState(
         material.map = state.sourceTextures[diffuseOverrideKey];
     }
 
+    material.transparent =
+        state.sourceTransparent ||
+        state.alpha < 1 ||
+        Boolean(material.alphaMap);
     material.needsUpdate = true;
 }
 
 function getMaterialBaseColor(material: DiveInspectableMaterial) {
     return `#${material.color.getHexString()}`;
+}
+
+function getMaterialEmissiveColor(material: DiveInspectableMaterial) {
+    return `#${material.emissive.getHexString()}`;
+}
+
+function getMaterialNormalScale(
+    material: DiveInspectableMaterial,
+): DiveMaterialNormalScale {
+    return {
+        x: material.normalScale.x,
+        y: material.normalScale.y,
+    };
 }
 
 function createMapRecord<Value>(


### PR DESCRIPTION
A rework/overhaul to the material demo that
- adds more PBR base properties like roughness and metalness values
- adds more refined property structure
- adds emissive control (map and values)
- removes "Only" mode, has to be done manually from now on